### PR TITLE
[feat] add reusable build and test workflow

### DIFF
--- a/.github/workflows/reusable-build-test-workflow.yml
+++ b/.github/workflows/reusable-build-test-workflow.yml
@@ -1,0 +1,100 @@
+name: Build and Test
+
+on:
+  workflow_call:
+    inputs:
+      sha:
+        required: true
+        type: string
+      ENVIRONMENT:
+        required: true
+        type: string
+    secrets:
+      RPC_PROVIDER_URL:
+        required: true
+      WALLET_PRIVATE_KEY:
+        required: true
+      TEST_WALLET_ADDRESS:
+        required: true
+      SEPOLIA_RPC_PROVIDER_URL:
+        required: true
+      TEST_SEPOLIA_RPC_PROVIDER_URL:
+        required: true
+      SEPOLIA_WALLET_PRIVATE_KEY:
+        required: true
+      SEPOLIA_TEST_WALLET_ADDRESS:
+        required: true
+      STORY_TEST_NET_RPC_PROVIDER_URL:
+        required: true
+      STORY_TEST_NET_WALLET_PRIVATE_KEY:
+        required: true
+      STORY_TEST_NET_TEST_WALLET_ADDRESS:
+        required: true
+
+jobs:
+  build_and_test:
+    name: Build and Test
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    ## Example to fix envrionment secret not passing in: https://github.com/AllanOricil/workflow-template-bug/blob/master/.github/workflows/workflow-template-fix-without-required-secret.yml
+    environment: ${{ inputs.ENVIRONMENT }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20.0.0]
+    env:
+      RPC_PROVIDER_URL: ${{ secrets.RPC_PROVIDER_URL }}
+      WALLET_PRIVATE_KEY: ${{ secrets.WALLET_PRIVATE_KEY }}
+      TEST_WALLET_ADDRESS: ${{ secrets.TEST_WALLET_ADDRESS }}
+      SEPOLIA_RPC_PROVIDER_URL: ${{ secrets.SEPOLIA_RPC_PROVIDER_URL }}
+      TEST_SEPOLIA_RPC_PROVIDER_URL: ${{ secrets.TEST_SEPOLIA_RPC_PROVIDER_URL }}
+      SEPOLIA_WALLET_PRIVATE_KEY: ${{ secrets.SEPOLIA_WALLET_PRIVATE_KEY }}
+      SEPOLIA_TEST_WALLET_ADDRESS: ${{ secrets.SEPOLIA_TEST_WALLET_ADDRESS }}
+      STORY_TEST_NET_RPC_PROVIDER_URL: ${{ secrets.STORY_TEST_NET_RPC_PROVIDER_URL }}
+      STORY_TEST_NET_WALLET_PRIVATE_KEY: ${{ secrets.STORY_TEST_NET_WALLET_PRIVATE_KEY }}
+      STORY_TEST_NET_TEST_WALLET_ADDRESS: ${{ secrets.STORY_TEST_NET_TEST_WALLET_ADDRESS }}
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+        with:
+          ref: ${{ inputs.sha }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+        with:
+          version: 8
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Install dependencies
+        run: |
+          pnpm install
+
+      - name: Fix
+        run: |
+          pnpm fix
+
+      - name: Run Anvil
+        id: run_anvil
+        run: |
+          anvil --fork-url ${SEPOLIA_RPC_PROVIDER_URL} --block-time 1 --silent &
+        continue-on-error: false
+
+      - name: Test
+        if: steps.run_anvil.outcome == 'success'
+        run: |
+          pnpm test
+
+      - name: Build
+        run: 
+          pnpm build


### PR DESCRIPTION
## Description
<!-- Add a description of the changes that this PR introduces -->
This pull request is to add a reusable build and test workflow.

Some notes
1. each action is locked to a specific commit hash, and they will be monitored by dependbot once merged 
2. node version 20.0.0 is being selected, but we can add more node version later if needed
3. add `fail-fast` strategy once `anvil` step fails