### PR TITLE
Remove block time in build-test-workflow

### DIFF
--- a/.github/workflows/reusable-build-test-workflow.yml
+++ b/.github/workflows/reusable-build-test-workflow.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Run Anvil
         id: run_anvil
         run: |
-          anvil --fork-url ${SEPOLIA_RPC_PROVIDER_URL} --block-time 1 --silent &
+          anvil --fork-url ${SEPOLIA_RPC_PROVIDER_URL} --silent &
         continue-on-error: false
 
       - name: Test


### PR DESCRIPTION
## Description
The method of `executeWithSig` needs to be the signature, which always fails in the workflow.  I find the command           `anvil --fork-url ${SEPOLIA_RPC_PROVIDER_URL} --block-time 1 --silent &` cause signature failure.  I have tried in my local environment and reproduced the error. Once I use the command `anvil --fork-url ${SEPOLIA_RPC_PROVIDER_URL} --silent &`, it will pass it. 



## Test Plan 
- Use block time
<img width="946" alt="image" src="https://github.com/storyprotocol/gha-workflows/assets/146059114/95851104-6191-4c09-89b4-f1838b267990">

- Use the default of adding block time instead 
<img width="963" alt="image" src="https://github.com/storyprotocol/gha-workflows/assets/146059114/930fbc2b-c7ca-4453-8f16-7d4c5ad6d4ef">


I dig into the issue, the `block time` means mining modes refer to how frequent blocks are mined using Anvi. By default, it automatically generates a new block as soon as a transaction is submitted. I am not sure of the detailed reason for block time and signature, but I have verified it locally. 

