### PR TITLE
Add tag name input to create github release reusable workflow

### DIFF
--- a/.github/workflows/reusable-create-release.yml
+++ b/.github/workflows/reusable-create-release.yml
@@ -7,6 +7,10 @@ on:
         type: string
         required: true
         description: 'Version to be published'
+      tag_to_publish:
+        type: string
+        required: false
+        description: 'Tag name to be published'
 
 permissions:
   contents: write
@@ -51,4 +55,5 @@ jobs:
         uses: mikepenz/action-gh-release@v0.2.0-a03 #softprops/action-gh-release
         with:
           tag_name: v${{ inputs.version_to_publish }}
+          name: '${{ inputs.tag_to_publish }} v${{ inputs.version_to_publish }}'
           body: ${{ steps.build_changelog.outputs.changelog }}

--- a/docs/security/readme-reusable-secrets-scanning.md
+++ b/docs/security/readme-reusable-secrets-scanning.md
@@ -1,0 +1,19 @@
+# Workflow Configuration
+
+## Name
+
+Reusable secret scanning workflow
+
+## Triggers
+
+ - Workflow Call
+
+## Inputs
+
+- Branch (string): required
+- Depth (number): required, default is 2
+  
+## Secrets
+
+- SLACK_BOT_TOKEN (required)
+- SLACK_CHANNEL_ID_GITHUB_NOTIFICATION (required)

--- a/docs/utility/readme-reusable-lint-go-workflow.md
+++ b/docs/utility/readme-reusable-lint-go-workflow.md
@@ -1,0 +1,17 @@
+# Workflow Configuration
+
+## Name
+
+Reusable go linting workflow
+
+## Triggers
+
+ - Workflow call
+
+## Inputs
+
+- Go Version (string): required, version of Go to lint
+  
+## Secrets
+
+ - N/A

--- a/docs/utility/readme-reusable-timestamp.md
+++ b/docs/utility/readme-reusable-timestamp.md
@@ -1,0 +1,18 @@
+# Workflow Configuration
+
+## Name
+
+Reusable timestamp workflow
+
+## Triggers
+
+ - Workflow call
+
+## Inputs
+
+- Timezone (string): required, timezone of workflow, default is LA/America
+- Workflow input #2 (type):
+  
+## Secrets
+
+- N/A

--- a/docs/utility/readme-reusable-timestamp.md
+++ b/docs/utility/readme-reusable-timestamp.md
@@ -11,7 +11,6 @@ Reusable timestamp workflow
 ## Inputs
 
 - Timezone (string): required, timezone of workflow, default is LA/America
-- Workflow input #2 (type):
   
 ## Secrets
 


### PR DESCRIPTION
## Description
Added tag name input for reusable-create-release to distinguish between different releases. Updated documentation for several workflows.

## Test Plan 
<!-- The test plan section indicates detailed steps on how to verify and test code changes. 
You can list the test cases or test steps that need to be performed.-->
Example: 
- 1. Use different test accounts for login tests, including correct user names and passwords, and incorrect user names and passwords.
- 2. ...

## Related Issue
<!-- The related Issue section can indicate which issue or task the Pull Request is related with -->

Example: Issue #123

## Notes
<!-- The Important Matters section can alert others to special requirements or matters that need extra attention -->

- Example: Links and navigation need to be added to the front-end interface