### PR TITLE
Update create release workflow

### DIFF
--- a/.github/workflows/reusable-create-release.yml
+++ b/.github/workflows/reusable-create-release.yml
@@ -44,12 +44,12 @@ jobs:
 
       - name: Build Changelog
         id: build_changelog
-        uses: mikepenz/release-changelog-builder-action@v4
+        uses: mikepenz/release-changelog-builder-action@v5.0.0-a04
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Release
-        uses: mikepenz/action-gh-release@v0.2.0-a03 #softprops/action-gh-release
+        uses: mikepenz/action-gh-release@v1 #softprops/action-gh-release
         with:
           tag_name: ${{ inputs.tag_name }}
           body: ${{ steps.build_changelog.outputs.changelog }}

--- a/.github/workflows/reusable-create-release.yml
+++ b/.github/workflows/reusable-create-release.yml
@@ -3,10 +3,10 @@ name: Reusable workflow to create release in GitHub
 on:
   workflow_call:
     inputs:
-      version_to_publish:
+      tag_name:
         type: string
         required: true
-        description: 'Version to be published'
+        description: "Tag name to be published"
 
 permissions:
   contents: write
@@ -32,12 +32,13 @@ jobs:
       - name: Tag and Push
         id: tag_and_push
         run: |
-          VERSION=${{ inputs.version_to_publish }}
+          TAG_NAME=${{ inputs.tag_name}}
           git config --global user.name 'GitHub Actions'
           git config --global user.email 'actions@github.com'
-          git tag -a v$VERSION -m "Release v$VERSION"
-          git push origin v$VERSION
-          echo "toTag=v$VERSION" >> $GITHUB_ENV
+          git tag -a $TAG_NAME -m "Release $TAG_NAME"
+          git push origin $TAG_NAME
+          echo "toTag=$TAG_NAME" >> $GITHUB_ENV
+          cat $GITHUB_ENV
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -50,5 +51,5 @@ jobs:
       - name: Create Release
         uses: mikepenz/action-gh-release@v0.2.0-a03 #softprops/action-gh-release
         with:
-          tag_name: v${{ inputs.version_to_publish }}
+          tag_name: ${{ inputs.tag_name }}
           body: ${{ steps.build_changelog.outputs.changelog }}


### PR DESCRIPTION
## Description
We need flexible tag names for two packages in our mono repo to accommodate new requirements. We'll establish a naming convention that distinguishes between the packages and automate the tag generation process accordingly.

Scope
- 1. Make workflow accept tag name as input
- 2. Update some action versions to fix the warning

## Test Plan 
Test in fork repo

<img width="746" alt="image" src="https://github.com/storyprotocol/gha-workflows/assets/146059114/558e4f8c-01e0-4cd9-8a12-9128de546bfe">
<img width="512" alt="image" src="https://github.com/storyprotocol/gha-workflows/assets/146059114/9fdb462d-6278-47dd-ab08-0cc84044d069">
