### PR TITLE
[fix] increase golangci timeout to 5 mins

### DIFF
--- a/.github/workflows/reusable-lint-go-workflow.yml
+++ b/.github/workflows/reusable-lint-go-workflow.yml
@@ -25,4 +25,4 @@ jobs:
         run: |
           echo "Running golangci-lint"
           go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-          golangci-lint run
+          golangci-lint run --timeout 5m


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow to include a timeout for the linting process, improving execution control and preventing indefinite hangs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->