### PR TITLE
[fix] temp solution to disable trivy scanning

### DIFF
--- a/.github/workflows/reusable-ecr-build-push.yml
+++ b/.github/workflows/reusable-ecr-build-push.yml
@@ -52,15 +52,16 @@ jobs:
             -t ${{ secrets.AWS_ACCOUNT_TARGET }}.dkr.ecr.${{ inputs.ecr-repo-aws-region }}.amazonaws.com/${{ inputs.ecr-repo }}:${{ github.sha }} \
             -t ${{ secrets.AWS_ACCOUNT_TARGET }}.dkr.ecr.${{ inputs.ecr-repo-aws-region }}.amazonaws.com/${{ inputs.ecr-repo }}:latest .
 
-      - name: Run Trivy vulnerability scanner
-        id: trivy
-        uses: aquasecurity/trivy-action@b2933f565dbc598b29947660e66259e3c7bc8561 # v0.20.0
-        with:
-          image-ref: ${{ secrets.AWS_ACCOUNT_TARGET }}.dkr.ecr.${{ inputs.ecr-repo-aws-region }}.amazonaws.com/${{ inputs.ecr-repo }}:${{ github.sha }}
-          format: 'table'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
+      # TEMPORARY DISABLED due to DB downloading rate limit from Trivy
+      # - name: Run Trivy vulnerability scanner
+      #   id: trivy
+      #   uses: aquasecurity/trivy-action@b2933f565dbc598b29947660e66259e3c7bc8561 # v0.20.0
+      #   with:
+      #     image-ref: ${{ secrets.AWS_ACCOUNT_TARGET }}.dkr.ecr.${{ inputs.ecr-repo-aws-region }}.amazonaws.com/${{ inputs.ecr-repo }}:${{ github.sha }}
+      #     format: 'table'
+      #     ignore-unfixed: true
+      #     vuln-type: 'os,library'
+      #     severity: 'CRITICAL,HIGH'
 
       - name: Get AWS ECR login using oidc token
         run: |


### PR DESCRIPTION
**CONTEXT**

We decided temporally disable the Trivy scanning due to rate limiting from the project. 

This issue is well know since Sep this year.

We will come back later to find a walkaround. 