### PR TITLE
Origin/bpolania/workflows

### DIFF
--- a/.github/workflows/reusable-build-integration-test-workflow.yml
+++ b/.github/workflows/reusable-build-integration-test-workflow.yml
@@ -46,23 +46,15 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
-
       - name: Install dependencies
-        run: |
-          pnpm install
+        run: pnpm install
 
       - name: Fix
-        run: |
-          pnpm fix
+        run: pnpm fix
 
       - name: Test
         run: |
           npm run test:integration
 
       - name: Build
-        run: 
-          pnpm build
+        run:  pnpm build

--- a/.github/workflows/reusable-build-integration-test-workflow.yml
+++ b/.github/workflows/reusable-build-integration-test-workflow.yml
@@ -10,25 +10,7 @@ on:
         required: true
         type: string
     secrets:
-      RPC_PROVIDER_URL:
-        required: true
       WALLET_PRIVATE_KEY:
-        required: true
-      TEST_WALLET_ADDRESS:
-        required: true
-      SEPOLIA_RPC_PROVIDER_URL:
-        required: true
-      TEST_SEPOLIA_RPC_PROVIDER_URL:
-        required: true
-      SEPOLIA_WALLET_PRIVATE_KEY:
-        required: true
-      SEPOLIA_TEST_WALLET_ADDRESS:
-        required: true
-      STORY_TEST_NET_RPC_PROVIDER_URL:
-        required: true
-      STORY_TEST_NET_WALLET_PRIVATE_KEY:
-        required: true
-      STORY_TEST_NET_TEST_WALLET_ADDRESS:
         required: true
 
 jobs:
@@ -42,16 +24,7 @@ jobs:
       matrix:
         node-version: [20.0.0]
     env:
-      RPC_PROVIDER_URL: ${{ secrets.RPC_PROVIDER_URL }}
       WALLET_PRIVATE_KEY: ${{ secrets.WALLET_PRIVATE_KEY }}
-      TEST_WALLET_ADDRESS: ${{ secrets.TEST_WALLET_ADDRESS }}
-      SEPOLIA_RPC_PROVIDER_URL: ${{ secrets.SEPOLIA_RPC_PROVIDER_URL }}
-      TEST_SEPOLIA_RPC_PROVIDER_URL: ${{ secrets.TEST_SEPOLIA_RPC_PROVIDER_URL }}
-      SEPOLIA_WALLET_PRIVATE_KEY: ${{ secrets.SEPOLIA_WALLET_PRIVATE_KEY }}
-      SEPOLIA_TEST_WALLET_ADDRESS: ${{ secrets.SEPOLIA_TEST_WALLET_ADDRESS }}
-      STORY_TEST_NET_RPC_PROVIDER_URL: ${{ secrets.STORY_TEST_NET_RPC_PROVIDER_URL }}
-      STORY_TEST_NET_WALLET_PRIVATE_KEY: ${{ secrets.STORY_TEST_NET_WALLET_PRIVATE_KEY }}
-      STORY_TEST_NET_TEST_WALLET_ADDRESS: ${{ secrets.STORY_TEST_NET_TEST_WALLET_ADDRESS }}
 
     steps:
       - name: Check out code

--- a/.github/workflows/reusable-build-integration-test-workflow.yml
+++ b/.github/workflows/reusable-build-integration-test-workflow.yml
@@ -12,6 +12,8 @@ on:
     secrets:
       WALLET_PRIVATE_KEY:
         required: true
+      TEST_WALLET_ADDRESS:
+        required: true
 
 jobs:
   build_and_test:
@@ -25,6 +27,7 @@ jobs:
         node-version: [20.0.0]
     env:
       WALLET_PRIVATE_KEY: ${{ secrets.WALLET_PRIVATE_KEY }}
+      TEST_WALLET_ADDRESS: ${{ secrets.TEST_WALLET_ADDRESS }}
 
     steps:
       - name: Check out code

--- a/.github/workflows/reusable-build-integration-test-workflow.yml
+++ b/.github/workflows/reusable-build-integration-test-workflow.yml
@@ -9,6 +9,27 @@ on:
       ENVIRONMENT:
         required: true
         type: string
+    secrets:
+      RPC_PROVIDER_URL:
+        required: true
+      WALLET_PRIVATE_KEY:
+        required: true
+      TEST_WALLET_ADDRESS:
+        required: true
+      SEPOLIA_RPC_PROVIDER_URL:
+        required: true
+      TEST_SEPOLIA_RPC_PROVIDER_URL:
+        required: true
+      SEPOLIA_WALLET_PRIVATE_KEY:
+        required: true
+      SEPOLIA_TEST_WALLET_ADDRESS:
+        required: true
+      STORY_TEST_NET_RPC_PROVIDER_URL:
+        required: true
+      STORY_TEST_NET_WALLET_PRIVATE_KEY:
+        required: true
+      STORY_TEST_NET_TEST_WALLET_ADDRESS:
+        required: true
 
 jobs:
   build_and_test:
@@ -20,6 +41,17 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [20.0.0]
+    env:
+      RPC_PROVIDER_URL: ${{ secrets.RPC_PROVIDER_URL }}
+      WALLET_PRIVATE_KEY: ${{ secrets.WALLET_PRIVATE_KEY }}
+      TEST_WALLET_ADDRESS: ${{ secrets.TEST_WALLET_ADDRESS }}
+      SEPOLIA_RPC_PROVIDER_URL: ${{ secrets.SEPOLIA_RPC_PROVIDER_URL }}
+      TEST_SEPOLIA_RPC_PROVIDER_URL: ${{ secrets.TEST_SEPOLIA_RPC_PROVIDER_URL }}
+      SEPOLIA_WALLET_PRIVATE_KEY: ${{ secrets.SEPOLIA_WALLET_PRIVATE_KEY }}
+      SEPOLIA_TEST_WALLET_ADDRESS: ${{ secrets.SEPOLIA_TEST_WALLET_ADDRESS }}
+      STORY_TEST_NET_RPC_PROVIDER_URL: ${{ secrets.STORY_TEST_NET_RPC_PROVIDER_URL }}
+      STORY_TEST_NET_WALLET_PRIVATE_KEY: ${{ secrets.STORY_TEST_NET_WALLET_PRIVATE_KEY }}
+      STORY_TEST_NET_TEST_WALLET_ADDRESS: ${{ secrets.STORY_TEST_NET_TEST_WALLET_ADDRESS }}
 
     steps:
       - name: Check out code

--- a/.github/workflows/reusable-build-integration-test-workflow.yml
+++ b/.github/workflows/reusable-build-integration-test-workflow.yml
@@ -1,0 +1,60 @@
+name: Build and Test
+
+on:
+  workflow_call:
+    inputs:
+      sha:
+        required: true
+        type: string
+      ENVIRONMENT:
+        required: true
+        type: string
+
+jobs:
+  build_and_test:
+    name: Build and Test
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.ENVIRONMENT }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20.0.0]
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+        with:
+          ref: ${{ inputs.sha }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+        with:
+          version: 8
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Install dependencies
+        run: |
+          pnpm install
+
+      - name: Fix
+        run: |
+          pnpm fix
+
+      - name: Test
+        run: |
+          npm run test:integration
+
+      - name: Build
+        run: 
+          pnpm build

--- a/.github/workflows/reusable-build-test-workflow.yml
+++ b/.github/workflows/reusable-build-test-workflow.yml
@@ -20,7 +20,6 @@ jobs:
     name: Build and Test
     timeout-minutes: 60
     runs-on: ubuntu-latest
-    ## Example to fix envrionment secret not passing in: https://github.com/AllanOricil/workflow-template-bug/blob/master/.github/workflows/workflow-template-fix-without-required-secret.yml
     environment: ${{ inputs.ENVIRONMENT }}
     strategy:
       fail-fast: false

--- a/.github/workflows/reusable-build-unit-test-workflow.yml
+++ b/.github/workflows/reusable-build-unit-test-workflow.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Test
         run: |
-          npm run test:unit
+          pnpm run test:unit
 
       - name: Build
         run: 

--- a/.github/workflows/reusable-build-unit-test-workflow.yml
+++ b/.github/workflows/reusable-build-unit-test-workflow.yml
@@ -10,7 +10,7 @@ on:
         required: true
         type: string
     secrets:
-      STORY_TEST_NET_WALLET_PRIVATE_KEY:
+      WALLET_PRIVATE_KEY:
         required: true
 
 jobs:
@@ -25,7 +25,7 @@ jobs:
       matrix:
         node-version: [20.0.0]
     env:
-      STORY_TEST_NET_WALLET_PRIVATE_KEY: ${{ secrets.STORY_TEST_NET_WALLET_PRIVATE_KEY }}
+      WALLET_PRIVATE_KEY: ${{ secrets.WALLET_PRIVATE_KEY }}
 
     steps:
       - name: Check out code

--- a/.github/workflows/reusable-build-unit-test-workflow.yml
+++ b/.github/workflows/reusable-build-unit-test-workflow.yml
@@ -30,11 +30,8 @@ jobs:
         node-version: [20.0.0]
     env:
       WALLET_PRIVATE_KEY: ${{ secrets.WALLET_PRIVATE_KEY }}
-      TEST_WALLET_ADDRESS: ${{ secrets.TEST_WALLET_ADDRESS }}
       SEPOLIA_WALLET_PRIVATE_KEY: ${{ secrets.SEPOLIA_WALLET_PRIVATE_KEY }}
-      SEPOLIA_TEST_WALLET_ADDRESS: ${{ secrets.SEPOLIA_TEST_WALLET_ADDRESS }}
       STORY_TEST_NET_WALLET_PRIVATE_KEY: ${{ secrets.STORY_TEST_NET_WALLET_PRIVATE_KEY }}
-      STORY_TEST_NET_TEST_WALLET_ADDRESS: ${{ secrets.STORY_TEST_NET_TEST_WALLET_ADDRESS }}
 
     steps:
       - name: Check out code

--- a/.github/workflows/reusable-build-unit-test-workflow.yml
+++ b/.github/workflows/reusable-build-unit-test-workflow.yml
@@ -12,6 +12,8 @@ on:
     secrets:
       WALLET_PRIVATE_KEY:
         required: true
+      TEST_WALLET_ADDRESS:
+        required: true
 
 jobs:
   build_and_test:
@@ -26,6 +28,7 @@ jobs:
         node-version: [20.0.0]
     env:
       WALLET_PRIVATE_KEY: ${{ secrets.WALLET_PRIVATE_KEY }}
+      TEST_WALLET_ADDRESS: ${{ secrets.TEST_WALLET_ADDRESS }}
 
     steps:
       - name: Check out code

--- a/.github/workflows/reusable-build-unit-test-workflow.yml
+++ b/.github/workflows/reusable-build-unit-test-workflow.yml
@@ -47,23 +47,14 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
-
       - name: Install dependencies
-        run: |
-          pnpm install
+        run: pnpm install
 
       - name: Fix
-        run: |
-          pnpm fix
+        run: pnpm fix
 
       - name: Test
-        run: |
-          pnpm test
+        run: pnpm test
 
       - name: Build
-        run: 
-          pnpm build
+        run: pnpm build

--- a/.github/workflows/reusable-build-unit-test-workflow.yml
+++ b/.github/workflows/reusable-build-unit-test-workflow.yml
@@ -10,21 +10,13 @@ on:
         required: true
         type: string
     secrets:
-      RPC_PROVIDER_URL:
-        required: true
       WALLET_PRIVATE_KEY:
         required: true
       TEST_WALLET_ADDRESS:
         required: true
-      SEPOLIA_RPC_PROVIDER_URL:
-        required: true
-      TEST_SEPOLIA_RPC_PROVIDER_URL:
-        required: true
       SEPOLIA_WALLET_PRIVATE_KEY:
         required: true
       SEPOLIA_TEST_WALLET_ADDRESS:
-        required: true
-      STORY_TEST_NET_RPC_PROVIDER_URL:
         required: true
       STORY_TEST_NET_WALLET_PRIVATE_KEY:
         required: true
@@ -43,14 +35,10 @@ jobs:
       matrix:
         node-version: [20.0.0]
     env:
-      RPC_PROVIDER_URL: ${{ secrets.RPC_PROVIDER_URL }}
       WALLET_PRIVATE_KEY: ${{ secrets.WALLET_PRIVATE_KEY }}
       TEST_WALLET_ADDRESS: ${{ secrets.TEST_WALLET_ADDRESS }}
-      SEPOLIA_RPC_PROVIDER_URL: ${{ secrets.SEPOLIA_RPC_PROVIDER_URL }}
-      TEST_SEPOLIA_RPC_PROVIDER_URL: ${{ secrets.TEST_SEPOLIA_RPC_PROVIDER_URL }}
       SEPOLIA_WALLET_PRIVATE_KEY: ${{ secrets.SEPOLIA_WALLET_PRIVATE_KEY }}
       SEPOLIA_TEST_WALLET_ADDRESS: ${{ secrets.SEPOLIA_TEST_WALLET_ADDRESS }}
-      STORY_TEST_NET_RPC_PROVIDER_URL: ${{ secrets.STORY_TEST_NET_RPC_PROVIDER_URL }}
       STORY_TEST_NET_WALLET_PRIVATE_KEY: ${{ secrets.STORY_TEST_NET_WALLET_PRIVATE_KEY }}
       STORY_TEST_NET_TEST_WALLET_ADDRESS: ${{ secrets.STORY_TEST_NET_TEST_WALLET_ADDRESS }}
 

--- a/.github/workflows/reusable-build-unit-test-workflow.yml
+++ b/.github/workflows/reusable-build-unit-test-workflow.yml
@@ -12,8 +12,6 @@ on:
     secrets:
       WALLET_PRIVATE_KEY:
         required: true
-      SEPOLIA_WALLET_PRIVATE_KEY:
-        required: true
       STORY_TEST_NET_WALLET_PRIVATE_KEY:
         required: true
 

--- a/.github/workflows/reusable-build-unit-test-workflow.yml
+++ b/.github/workflows/reusable-build-unit-test-workflow.yml
@@ -12,15 +12,9 @@ on:
     secrets:
       WALLET_PRIVATE_KEY:
         required: true
-      TEST_WALLET_ADDRESS:
-        required: true
       SEPOLIA_WALLET_PRIVATE_KEY:
         required: true
-      SEPOLIA_TEST_WALLET_ADDRESS:
-        required: true
       STORY_TEST_NET_WALLET_PRIVATE_KEY:
-        required: true
-      STORY_TEST_NET_TEST_WALLET_ADDRESS:
         required: true
 
 jobs:

--- a/.github/workflows/reusable-build-unit-test-workflow.yml
+++ b/.github/workflows/reusable-build-unit-test-workflow.yml
@@ -28,7 +28,6 @@ jobs:
         node-version: [20.0.0]
     env:
       WALLET_PRIVATE_KEY: ${{ secrets.WALLET_PRIVATE_KEY }}
-      SEPOLIA_WALLET_PRIVATE_KEY: ${{ secrets.SEPOLIA_WALLET_PRIVATE_KEY }}
       STORY_TEST_NET_WALLET_PRIVATE_KEY: ${{ secrets.STORY_TEST_NET_WALLET_PRIVATE_KEY }}
 
     steps:

--- a/.github/workflows/reusable-build-unit-test-workflow.yml
+++ b/.github/workflows/reusable-build-unit-test-workflow.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Test
         run: |
-          pnpm run test:unit
+          pnpm test:unit
 
       - name: Build
         run: 

--- a/.github/workflows/reusable-build-unit-test-workflow.yml
+++ b/.github/workflows/reusable-build-unit-test-workflow.yml
@@ -9,6 +9,27 @@ on:
       ENVIRONMENT:
         required: true
         type: string
+    secrets:
+      RPC_PROVIDER_URL:
+        required: true
+      WALLET_PRIVATE_KEY:
+        required: true
+      TEST_WALLET_ADDRESS:
+        required: true
+      SEPOLIA_RPC_PROVIDER_URL:
+        required: true
+      TEST_SEPOLIA_RPC_PROVIDER_URL:
+        required: true
+      SEPOLIA_WALLET_PRIVATE_KEY:
+        required: true
+      SEPOLIA_TEST_WALLET_ADDRESS:
+        required: true
+      STORY_TEST_NET_RPC_PROVIDER_URL:
+        required: true
+      STORY_TEST_NET_WALLET_PRIVATE_KEY:
+        required: true
+      STORY_TEST_NET_TEST_WALLET_ADDRESS:
+        required: true
 
 jobs:
   build_and_test:
@@ -21,6 +42,17 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [20.0.0]
+    env:
+      RPC_PROVIDER_URL: ${{ secrets.RPC_PROVIDER_URL }}
+      WALLET_PRIVATE_KEY: ${{ secrets.WALLET_PRIVATE_KEY }}
+      TEST_WALLET_ADDRESS: ${{ secrets.TEST_WALLET_ADDRESS }}
+      SEPOLIA_RPC_PROVIDER_URL: ${{ secrets.SEPOLIA_RPC_PROVIDER_URL }}
+      TEST_SEPOLIA_RPC_PROVIDER_URL: ${{ secrets.TEST_SEPOLIA_RPC_PROVIDER_URL }}
+      SEPOLIA_WALLET_PRIVATE_KEY: ${{ secrets.SEPOLIA_WALLET_PRIVATE_KEY }}
+      SEPOLIA_TEST_WALLET_ADDRESS: ${{ secrets.SEPOLIA_TEST_WALLET_ADDRESS }}
+      STORY_TEST_NET_RPC_PROVIDER_URL: ${{ secrets.STORY_TEST_NET_RPC_PROVIDER_URL }}
+      STORY_TEST_NET_WALLET_PRIVATE_KEY: ${{ secrets.STORY_TEST_NET_WALLET_PRIVATE_KEY }}
+      STORY_TEST_NET_TEST_WALLET_ADDRESS: ${{ secrets.STORY_TEST_NET_TEST_WALLET_ADDRESS }}
 
     steps:
       - name: Check out code

--- a/.github/workflows/reusable-build-unit-test-workflow.yml
+++ b/.github/workflows/reusable-build-unit-test-workflow.yml
@@ -1,0 +1,61 @@
+name: Build and Test
+
+on:
+  workflow_call:
+    inputs:
+      sha:
+        required: true
+        type: string
+      ENVIRONMENT:
+        required: true
+        type: string
+
+jobs:
+  build_and_test:
+    name: Build and Test
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    ## Example to fix envrionment secret not passing in: https://github.com/AllanOricil/workflow-template-bug/blob/master/.github/workflows/workflow-template-fix-without-required-secret.yml
+    environment: ${{ inputs.ENVIRONMENT }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20.0.0]
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+        with:
+          ref: ${{ inputs.sha }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+        with:
+          version: 8
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Install dependencies
+        run: |
+          pnpm install
+
+      - name: Fix
+        run: |
+          pnpm fix
+
+      - name: Test
+        run: |
+          npm run test:unit
+
+      - name: Build
+        run: 
+          pnpm build

--- a/.github/workflows/reusable-build-unit-test-workflow.yml
+++ b/.github/workflows/reusable-build-unit-test-workflow.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Test
         run: |
-          pnpm test:unit
+          pnpm test
 
       - name: Build
         run: 

--- a/.github/workflows/reusable-build-unit-test-workflow.yml
+++ b/.github/workflows/reusable-build-unit-test-workflow.yml
@@ -20,7 +20,6 @@ jobs:
     name: Build and Test
     timeout-minutes: 60
     runs-on: ubuntu-latest
-    ## Example to fix envrionment secret not passing in: https://github.com/AllanOricil/workflow-template-bug/blob/master/.github/workflows/workflow-template-fix-without-required-secret.yml
     environment: ${{ inputs.ENVIRONMENT }}
     strategy:
       fail-fast: false

--- a/.github/workflows/reusable-build-unit-test-workflow.yml
+++ b/.github/workflows/reusable-build-unit-test-workflow.yml
@@ -10,8 +10,6 @@ on:
         required: true
         type: string
     secrets:
-      WALLET_PRIVATE_KEY:
-        required: true
       STORY_TEST_NET_WALLET_PRIVATE_KEY:
         required: true
 
@@ -27,7 +25,6 @@ jobs:
       matrix:
         node-version: [20.0.0]
     env:
-      WALLET_PRIVATE_KEY: ${{ secrets.WALLET_PRIVATE_KEY }}
       STORY_TEST_NET_WALLET_PRIVATE_KEY: ${{ secrets.STORY_TEST_NET_WALLET_PRIVATE_KEY }}
 
     steps:


### PR DESCRIPTION
## Description

This is an update aiming to improve SDK's workflows, with the final objective of separating unit and integration tests, so the latest can be run after the merge.

* Two new workflows were created to deal with `unit` and `integration` tests separately.  
   - `reusable-build-unit-test-workflow`
   - `reusable-build-integration-test-workflow`
* Original `reusable-build-test-workflow` is not being deleted because it will might disrupt flows outside the SDK workflows.
* Removed unused comments.

## Test Plan 
These workflows can be tested by making PR to the `/origin/dev-polania/workflows` branch of the SDK repo. It will trigger the two new workflows.

