### PR TITLE
Update reusable-build-integration-test-workflow.yml

### DIFF
--- a/.github/workflows/reusable-build-integration-test-workflow.yml
+++ b/.github/workflows/reusable-build-integration-test-workflow.yml
@@ -14,8 +14,6 @@ on:
         required: true
       TEST_WALLET_ADDRESS:
         required: true
-      JUDGE_PRIVATE_KEY:
-        required: true
 
 jobs:
   build_and_test:
@@ -30,7 +28,6 @@ jobs:
     env:
       WALLET_PRIVATE_KEY: ${{ secrets.WALLET_PRIVATE_KEY }}
       TEST_WALLET_ADDRESS: ${{ secrets.TEST_WALLET_ADDRESS }}
-      JUDGE_PRIVATE_KEY: ${{ secrets.JUDGE_PRIVATE_KEY }}
 
     steps:
       - name: Check out code


### PR DESCRIPTION
## Description

This PR removes the requirement for the `JUDGE_PRIVATE_KEY` env variable. It is now unnecessary after the latest changes to the `aeneid` Dispute modules.