### PR TITLE
Update README workflow index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Reusable GitHub Action Workflows
 
+[![Workflow Lint](https://img.shields.io/github/actions/workflow/status/storyprotocol/gha-workflows/lint-validation.yml?branch=main&label=workflow%20lint)](https://github.com/storyprotocol/gha-workflows/actions/workflows/lint-validation.yml)
+[![Secrets Scan](https://img.shields.io/github/actions/workflow/status/storyprotocol/gha-workflows/secrets-scanning.yml?branch=main&label=secrets%20scan)](https://github.com/storyprotocol/gha-workflows/actions/workflows/secrets-scanning.yml)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](.pre-commit-config.yaml)
+[![Stars](https://img.shields.io/github/stars/storyprotocol/gha-workflows?style=flat&label=stars)](https://github.com/storyprotocol/gha-workflows/stargazers)
+[![Forks](https://img.shields.io/github/forks/storyprotocol/gha-workflows?style=flat&label=forks)](https://github.com/storyprotocol/gha-workflows/forks)
+
 This repository contains reusable GitHub Actions workflows used across Story
 Protocol repositories, plus a small set of workflows that maintain this
 repository itself.

--- a/README.md
+++ b/README.md
@@ -1,252 +1,148 @@
 # Reusable GitHub Action Workflows
 
-This repository contains a comprehensive collection of reusable GitHub Action workflows designed to streamline CI/CD, security, testing, and operational processes across Story Protocol projects.
+This repository contains reusable GitHub Actions workflows used across Story
+Protocol repositories, plus a small set of workflows that maintain this
+repository itself.
+
+The source of truth is `.github/workflows/`. Workflow inputs and outputs are
+defined under `on.workflow_call`; some older workflows also reference repository
+secrets or variables directly.
 
 ## Quick Start
 
-To use any of these workflows in your repository:
+Use a reusable workflow from another repository with `jobs.<job_id>.uses`:
 
 ```yaml
-jobs:
-  my-job:
-    uses: storyprotocol/gha-workflows/.github/workflows/<workflow-filename>@main
-    with:
-      # workflow inputs
-    secrets:
-      # workflow secrets
-```
-
-## Workflow Categories
-
-### 🛠️ Utility Workflows
-
-General-purpose workflows for common operations.
-
-| Workflow | Purpose | Key Features | When to Use |
-|----------|---------|--------------|-------------|
-| [reusable-timestamp.yml](docs/utility/readme-reusable-timestamp.md) | Generate timestamps in specific timezones | • Configurable timezone<br>• Environment variable output<br>• Useful for versioning | Creating time-based identifiers, logging execution times |
-| [reusable-lint-go-workflow.yml](docs/utility/readme-reusable-lint-go-workflow.md) | Lint Go code with golangci-lint | • Configurable Go version<br>• 5-minute timeout<br>• Latest golangci-lint | Ensuring Go code quality in PRs and main branch |
-| [reusable-slack-notifs.yml](docs/utility/readme-reusable-slack-notifs.md) | Send formatted Slack notifications | • Rich message formatting<br>• Optional image support<br>• Markdown support | Build notifications, deployment alerts, failure alerts |
-
-### 🚀 CI/CD Workflows
-
-Build, test, and deployment workflows for various platforms and technologies.
-
-#### Container Build & Push
-
-| Workflow | Purpose | Key Features | When to Use |
-|----------|---------|--------------|-------------|
-| [reusable-ecr-build-push.yml](docs/cicd/readme-reusable-ecr-build-push.md) | Build and push Go API Docker images to AWS ECR | • OIDC authentication<br>• Go test execution<br>• Trivy scanning<br>• SHA + latest tags | Deploying Go API services to AWS |
-| [reusable-ecr-build-push-temporal-worker.yml](docs/cicd/readme-reusable-ecr-build-push-temporal-worker.md) | Build and push Temporal worker images to AWS ECR | • Custom image tags<br>• OIDC authentication<br>• Temporal-specific Dockerfile | Deploying Temporal workers to AWS |
-| [reusable-gcp-image-build-worker.yml](docs/cicd/readme-reusable-gcp-build-push.md) | Build and push Docker images to GCP Container Registry | • Environment-aware<br>• Flexible Dockerfile paths<br>• Environment variables support | Deploying containerized apps to GCP |
-| [reusable-gcp-app-release-publisher.yml](docs/cicd/readme-reusable-gcp-app-release-publisher.md) | Publish release messages to GCP Pub/Sub | • Triggers deployments<br>• Environment mapping<br>• Structured JSON messages | Triggering GCP deployments via Pub/Sub |
-
-#### Testing Workflows
-
-| Workflow | Purpose | Key Features | When to Use |
-|----------|---------|--------------|-------------|
-| [reusable-build-test-workflow.yml](docs/cicd/readme-reusable-build-test-workflow.md) | Full build and test for Node.js projects | • Mochawesome reports<br>• GitHub Pages deployment<br>• Test artifacts | Comprehensive testing with visual reports |
-| [reusable-build-unit-test-workflow.yml](docs/cicd/readme-reusable-build-unit-test-workflow.md) | Unit testing for Node.js projects | • Fast execution<br>• No report generation<br>• PR-friendly | Quick unit test validation |
-| [reusable-build-integration-test-workflow.yml](docs/cicd/readme-reusable-build-integration-test-workflow.md) | Integration testing for Node.js projects | • Isolated integration tests<br>• Environment-specific | Testing external integrations |
-| [reusable-build-python-unit-test-workflow.yml](docs/cicd/readme-reusable-build-python-unit-test-workflow.md) | Unit testing for Python projects | • Multi-version testing<br>• Coverage reports<br>• Virtual environments | Python service testing |
-| [reusable-build-python-integration-test-workflow.yml](docs/cicd/readme-reusable-build-python-integration-test-workflow.md) | Integration testing for Python projects | • pytest-based<br>• Coverage included<br>• RPC testing support | Python integration validation |
-
-#### Release Management
-
-| Workflow | Purpose | Key Features | When to Use |
-|----------|---------|--------------|-------------|
-| [reusable-create-release.yml](docs/cicd/readme-reusable-create-release.md) | Create GitHub releases with changelogs | • Automated changelog<br>• Tag creation<br>• Previous tag detection | Creating versioned releases |
-
-### 🔒 Security Workflows
-
-Security scanning, access management, and infrastructure security workflows.
-
-#### Scanning & Monitoring
-
-| Workflow | Purpose | Key Features | When to Use |
-|----------|---------|--------------|-------------|
-| [reusable-secrets-scanning.yml](docs/security/readme-reusable-secrets-scanning.md) | Scan for hardcoded secrets with TruffleHog | • Verified secrets only<br>• Slack notifications<br>• Configurable depth | Preventing secret leaks |
-| [secrets-scanning.yml](docs/security/readme-reusable-secrets-scanning.md) | Automatic secrets scanning on main branch | • Auto-triggers on push<br>• Calls reusable workflow | Continuous security monitoring |
-| [scorecards.yml](docs/security/readme-reusable-scorecards.md) | OSSF Scorecards security assessment | • SARIF format output<br>• Code scanning integration<br>• Manual trigger | Security posture assessment |
-
-#### AWS Infrastructure Security
-
-| Workflow | Purpose | Key Features | When to Use |
-|----------|---------|--------------|-------------|
-| [reusable-fetch-bastion-ips.yml](docs/security/readme-reusable-fetch-bastion-ips.md) | Fetch bastion host IP addresses | • Multi-environment<br>• Conditional fetching<br>• EC2 tag filtering | Getting bastion IPs for access |
-| [reusable-fetch-network-node-ips.yml](docs/security/readme-reusable-fetch-network-node-ips.md) | Fetch all network node IPs across regions | • Multi-region support<br>• Bulk IP retrieval<br>• Node metadata | Network-wide IP discovery |
-| [reusable-fetch-security-group-ids.yml](docs/security/readme-reusable-fetch-security-group-ids.md) | Fetch security group IDs | • Multi-region<br>• Bastion + network SGs<br>• Region mapping | Dynamic SG management |
-| [reusable-parse-bastion-access-files.yml](docs/security/readme-reusable-parse-bastion-access-files.md) | Parse YAML access configs to JSON | • YAML to JSON conversion<br>• IP permissions format<br>• Multi-environment | Preparing access rules |
-| [reusable-update-security-groups.yml](docs/security/readme-reusable-update-security-groups.md) | Update security groups with new IPs | • Bulk updates<br>• Status tracking<br>• Multi-region | Adding access rules |
-| [reusable-revoke-inbound-rules.yml](docs/security/readme-reusable-revoke-inbound-rules.md) | Revoke all inbound rules from SGs | • Clean slate approach<br>• Multi-region<br>• Conditional execution | Resetting security groups |
-| [reusable-remove-gha-ip-from-sg.yml](docs/security/readme-reusable-remove-gha-ip-from-sg.md) | Remove GitHub Actions runner IPs | • Cleanup automation<br>• Multi-SG support<br>• Security hygiene | Post-deployment cleanup |
-
-### 🧪 QA Workflows
-
-Quality assurance and code coverage workflows.
-
-| Workflow | Purpose | Key Features | When to Use |
-|----------|---------|--------------|-------------|
-| [reusable-forge-code-coverage.yml](docs/qa/readme-reusable-forge-code-coverage.md) | Generate code coverage for Solidity contracts | • Foundry/Forge integration<br>• lcov + HTML reports<br>• Path exclusion<br>• Branch coverage | Smart contract test coverage |
-
-## Common Usage Patterns
-
-### 1. Complete CI/CD Pipeline
-
-```yaml
-name: CI/CD Pipeline
-on:
-  push:
-    branches: [main]
-  pull_request:
-
 jobs:
   lint:
     uses: storyprotocol/gha-workflows/.github/workflows/reusable-lint-go-workflow.yml@main
     with:
-      go-version: '1.22'
+      go-version: "1.22"
+```
 
-  test:
-    uses: storyprotocol/gha-workflows/.github/workflows/reusable-build-test-workflow.yml@main
-    with:
-      sha: ${{ github.sha }}
-      ENVIRONMENT: staging
-    secrets:
-      WALLET_PRIVATE_KEY: ${{ secrets.WALLET_PRIVATE_KEY }}
-      TEST_WALLET_ADDRESS: ${{ secrets.TEST_WALLET_ADDRESS }}
+For workflows that require secrets, pass the named secrets explicitly or use
+`secrets: inherit` only when that is allowed by the caller repository's policy.
 
-  security-scan:
-    uses: storyprotocol/gha-workflows/.github/workflows/reusable-secrets-scanning.yml@main
-    with:
-      branch: ${{ github.ref_name }}
-    secrets:
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      SLACK_CHANNEL_ID_GITHUB_NOTIFICATION: ${{ secrets.SLACK_CHANNEL_ID }}
-
-  build-and-push:
-    needs: [lint, test, security-scan]
-    if: github.ref == 'refs/heads/main'
-    uses: storyprotocol/gha-workflows/.github/workflows/reusable-ecr-build-push.yml@main
-    with:
-      ecr-repo: "my-api-service"
-      ecr-repo-aws-region: "us-east-1"
-    secrets:
-      AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
-      AWS_ACCOUNT_TARGET: ${{ secrets.AWS_ACCOUNT_TARGET }}
-
+```yaml
+jobs:
   notify:
-    needs: [build-and-push]
-    if: always()
     uses: storyprotocol/gha-workflows/.github/workflows/reusable-slack-notifs.yml@main
     with:
-      title: ${{ needs.build-and-push.result == 'success' && '✅ Deployment Successful' || '❌ Deployment Failed' }}
-      short-desc: 'Build ${{ github.sha }} has ${{ needs.build-and-push.result }}'
-      img-alt-text: 'Build status'
+      title: "Build completed"
+      short-desc: "The build finished successfully."
+      img-alt-text: "Build status"
     secrets:
       channel-name: ${{ secrets.SLACK_CHANNEL_ID }}
       slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
 ```
 
-### 2. Security Group Management Flow
+## Workflow Index
 
-```yaml
-name: Update Bastion Access
-on:
-  push:
-    paths:
-      - 'configs/bastion-access-*.yaml'
+### Utility
 
-jobs:
-  parse-configs:
-    uses: storyprotocol/gha-workflows/.github/workflows/reusable-parse-bastion-access-files.yml@main
-    with:
-      devnet_file: "configs/bastion-access-devnet.yaml"
-      testnet_file: "configs/bastion-access-testnet.yaml"
+| Workflow | Purpose |
+| --- | --- |
+| [`reusable-lint-go-workflow.yml`](.github/workflows/reusable-lint-go-workflow.yml) | Sets up Go and runs `golangci-lint run --timeout 5m`. |
+| [`reusable-slack-notifs.yml`](.github/workflows/reusable-slack-notifs.yml) | Sends Slack Block Kit notifications, with optional image support. |
+| [`reusable-timestamp.yml`](.github/workflows/reusable-timestamp.yml) | Generates and prints a timestamp for a configurable timezone. |
 
-  fetch-sg-ids:
-    uses: storyprotocol/gha-workflows/.github/workflows/reusable-fetch-security-group-ids.yml@main
-    with:
-      role_to_assume: ${{ secrets.AWS_ROLE }}
-      aws_region: "us-east-1"
-      # ... other inputs
+### CI/CD and Release
 
-  revoke-existing:
-    needs: [fetch-sg-ids]
-    uses: storyprotocol/gha-workflows/.github/workflows/reusable-revoke-inbound-rules.yml@main
-    with:
-      sg_ids_devnet: ${{ needs.fetch-sg-ids.outputs.security_group_ids_devnet }}
-      # ... other inputs
+| Workflow | Purpose |
+| --- | --- |
+| [`reusable-build-and-deploy.yml`](.github/workflows/reusable-build-and-deploy.yml) | Builds and pushes an ECR image, then updates image tags in a deployment config repository. |
+| [`reusable-create-release.yml`](.github/workflows/reusable-create-release.yml) | Creates an annotated Git tag and GitHub release with a generated changelog. |
+| [`reusable-ecr-build-push.yml`](.github/workflows/reusable-ecr-build-push.yml) | Runs `go test ./api/...`, builds `./dockerfile/api/Dockerfile`, and pushes SHA/latest tags to ECR. |
+| [`reusable-ecr-build-push-temporal-worker.yml`](.github/workflows/reusable-ecr-build-push-temporal-worker.yml) | Builds `./dockerfile/temporal-worker/Dockerfile` and pushes a custom image tag plus `latest` to ECR. |
+| [`reusable-gcp-app-release-publisher.yml`](.github/workflows/reusable-gcp-app-release-publisher.yml) | Publishes a release message to the configured GCP Pub/Sub courier topic. |
+| [`reusable-gcp-image-build-worker.yml`](.github/workflows/reusable-gcp-image-build-worker.yml) | Builds and pushes a Docker image to GCR for staging or production. |
 
-  update-sgs:
-    needs: [parse-configs, fetch-sg-ids, revoke-existing]
-    uses: storyprotocol/gha-workflows/.github/workflows/reusable-update-security-groups.yml@main
-    with:
-      ips_devnet: ${{ needs.parse-configs.outputs.ips_devnet }}
-      sg_ids_devnet: ${{ needs.fetch-sg-ids.outputs.security_group_ids_devnet }}
-      # ... other inputs
-```
+### Testing
 
-### 3. Multi-Environment Testing
+| Workflow | Purpose |
+| --- | --- |
+| [`reusable-build-integration-test-workflow.yml`](.github/workflows/reusable-build-integration-test-workflow.yml) | Runs Node/pnpm integration tests with `pnpm run test:integration`, then builds. |
+| [`reusable-build-python-integration-test-workflow.yml`](.github/workflows/reusable-build-python-integration-test-workflow.yml) | Runs Python 3.10/3.11 integration tests with pytest coverage. |
+| [`reusable-build-python-unit-test-workflow.yml`](.github/workflows/reusable-build-python-unit-test-workflow.yml) | Runs Python 3.10/3.11 unit tests with pytest coverage. |
+| [`reusable-build-test-workflow.yml`](.github/workflows/reusable-build-test-workflow.yml) | Runs Node/pnpm fix, test, and build steps, then uploads and publishes a Mochawesome report. |
+| [`reusable-build-unit-test-workflow.yml`](.github/workflows/reusable-build-unit-test-workflow.yml) | Runs Node/pnpm fix, test, and build steps without report publishing. |
 
-```yaml
-name: Multi-Environment Tests
-on: [push, pull_request]
+### Security and Access Management
 
-jobs:
-  unit-tests:
-    strategy:
-      matrix:
-        environment: [staging, production]
-    uses: storyprotocol/gha-workflows/.github/workflows/reusable-build-unit-test-workflow.yml@main
-    with:
-      sha: ${{ github.sha }}
-      ENVIRONMENT: ${{ matrix.environment }}
-    secrets:
-      WALLET_PRIVATE_KEY: ${{ secrets[format('WALLET_PRIVATE_KEY_{0}', matrix.environment)] }}
-      TEST_WALLET_ADDRESS: ${{ secrets[format('TEST_WALLET_ADDRESS_{0}', matrix.environment)] }}
-```
+| Workflow | Purpose |
+| --- | --- |
+| [`reusable-fetch-bastion-ips.yml`](.github/workflows/reusable-fetch-bastion-ips.yml) | Fetches DevNet/TestNet bastion public IPs from EC2 when related files changed. |
+| [`reusable-fetch-network-node-ips.yml`](.github/workflows/reusable-fetch-network-node-ips.yml) | Fetches DevNet/TestNet node IP data across caller-provided AWS regions. |
+| [`reusable-fetch-security-group-ids.yml`](.github/workflows/reusable-fetch-security-group-ids.yml) | Finds DevNet/TestNet security group IDs and bastion security group IDs. |
+| [`reusable-parse-bastion-access-files.yml`](.github/workflows/reusable-parse-bastion-access-files.yml) | Parses DevNet/TestNet bastion access YAML files into JSON permissions. |
+| [`reusable-remove-gha-ip-from-sg.yml`](.github/workflows/reusable-remove-gha-ip-from-sg.yml) | Removes a GitHub Actions runner IP from DevNet/TestNet security groups and bastion security groups. |
+| [`reusable-revoke-inbound-rules.yml`](.github/workflows/reusable-revoke-inbound-rules.yml) | Revokes inbound rules from DevNet/TestNet security groups. |
+| [`reusable-secrets-scanning.yml`](.github/workflows/reusable-secrets-scanning.yml) | Runs TruffleHog with `--only-verified` and sends a Slack notification on failure. |
+| [`reusable-update-security-groups.yml`](.github/workflows/reusable-update-security-groups.yml) | Adds parsed IP permissions to DevNet/TestNet security groups. |
+| [`scorecards.yml`](.github/workflows/scorecards.yml) | Manually runs OSSF Scorecards and uploads SARIF results to code scanning. |
+| [`secrets-scanning.yml`](.github/workflows/secrets-scanning.yml) | Calls the reusable TruffleHog scan on pushes to `main`. |
 
-## Best Practices
+### QA
 
-1. **Version Pinning**: All workflows use pinned action versions with SHA hashes for security. Regularly update these after security review.
+| Workflow | Purpose |
+| --- | --- |
+| [`reusable-forge-code-coverage.yml`](.github/workflows/reusable-forge-code-coverage.yml) | Runs Foundry coverage, filters paths with lcov, generates HTML, and uploads the coverage artifact. |
 
-2. **Secret Management**: 
-   - Use environment-specific secrets
-   - Pass secrets explicitly through the `secrets` context
-   - Never hardcode sensitive information
+### Repository Maintenance
 
-3. **Conditional Execution**: Many workflows support conditional execution based on environment changes. Use this to optimize CI/CD time.
+| File | Purpose |
+| --- | --- |
+| [`lint-validation.yml`](.github/workflows/lint-validation.yml) | Lints workflow YAML files and performs a basic workflow-name validation on workflow changes. |
+| [`dependabot.yml`](.github/dependabot.yml) | Checks GitHub Actions dependencies daily. |
+| [`.pre-commit-config.yaml`](.pre-commit-config.yaml) | Configures the `gitleaks` pre-commit hook. |
 
-4. **Error Handling**: Most workflows will fail fast on errors. Consider using `if: always()` for cleanup or notification steps.
+## Caller Requirements
 
-5. **Documentation**: Each workflow has its own documentation in the `docs/` directory. Keep these updated when modifying workflows.
+These workflows assume the caller repository supplies the expected repository
+layout, tools, variables, and secrets.
 
-## Requirements
+- AWS ECR workflows require an OIDC-capable AWS role or the expected
+  `AWS_ACCOUNT` / `AWS_ACCOUNT_TARGET` secrets, depending on the workflow.
+- `reusable-build-and-deploy.yml` requires `AWS_ROLE_ARN` and `DEPLOY_TOKEN`,
+  and writes image tag updates to a deployment config repository.
+- GCP workflows require the referenced service account secrets and Pub/Sub
+  variables, such as `COURIER_SERVICE_ACCOUNT_KEY` and `COURIER_TOPIC`.
+- Slack workflows require a Slack channel ID/name and bot token.
+- Node test workflows assume pnpm 8 and Node 20.
+- Python test workflows assume `requirements.txt` and `tests/unit` or
+  `tests/integration` exist in the caller repository.
+- Some workflows assume Story-specific paths, such as `./dockerfile/api`,
+  `./dockerfile/temporal-worker`, and `packages/core-sdk/mochawesome-report`.
 
-- GitHub Actions must be enabled in your repository
-- Appropriate secrets must be configured at the repository or organization level
-- For AWS workflows: OIDC provider must be configured
-- For GCP workflows: Service account keys must be available
-- For Slack workflows: Slack app with bot token must be configured
+The AWS access-management workflows call helper scripts from the checked-out
+caller repository. Callers must provide the scripts used by the selected
+workflow:
+
+- `scripts/parse_config.py`
+- `scripts/fetch_all_node_ips.sh`
+- `scripts/get_sg_id_by_name.sh`
+- `scripts/update_security_group.sh`
+- `scripts/revoke_inbound_rules.sh`
+- `scripts/remove_ip_from_sg.sh`
+
+## Validation
+
+This repository validates workflow changes through
+[`lint-validation.yml`](.github/workflows/lint-validation.yml), which runs
+yamllint using [`.github/linters/.yamllint.yml`](.github/linters/.yamllint.yml)
+and checks each workflow file has a `name` field.
+
+When changing a reusable workflow, also test it from a caller repository or a
+temporary workflow before merging.
 
 ## Contributing
 
-When adding new reusable workflows:
+When adding or changing a reusable workflow:
 
-1. Follow the naming convention: `reusable-<purpose>.yml`
-2. Include comprehensive input validation
-3. Use pinned action versions with SHA hashes
-4. Create documentation in `docs/<category>/readme-reusable-<name>.md`
-5. Update this README with the new workflow information
-6. Test thoroughly in a separate repository before merging
-
-## Security
-
-- All workflows use pinned action versions for security
-- Secrets are handled through GitHub's encrypted secrets
-- AWS workflows use OIDC for temporary credentials
-- Regular security scanning with TruffleHog and OSSF Scorecards
-
-## License
-
-[Include your license information here]
+1. Put the workflow in `.github/workflows/`.
+2. Keep the `workflow_call` inputs, outputs, and secrets explicit.
+3. Prefer SHA-pinned third-party actions when practical, and document any
+   intentional exception.
+4. Update this README with the workflow's current behavior.
+5. Add or update detailed docs under `docs/` only when they are kept in sync
+   with the workflow.


### PR DESCRIPTION
## Description

- Refresh the README to match the current `.github/workflows` inventory.
- Replace stale or missing docs links with direct links to workflow files.
- Add current caller requirements, validation notes, and contribution guidance.
- Add accurate README badges for workflow linting, TruffleHog scanning, pre-commit, stars, and forks.

## Test Plan

- Read the repository text files, docs stubs, configuration, and all workflow files.
- Confirmed the repository has no license metadata or `LICENSE` file, so no license badge was added.
- Checked OpenSSF Scorecard badge output and did not include it because it renders `invalid repo path` for this repository.
- Ran `git diff --check`.
- Ran a README link/workflow coverage check to confirm all local links exist and all `.github/workflows/*.yml` files are listed.
- Verified each final badge URL returns SVG content without `invalid`, `error`, or `no status` output.
- Ran `pre-commit run --all-files`.

## Notes

- Opened from `AndyBoWu/storyprotocol-gha-workflows` because the authenticated account has read-only access to `storyprotocol/gha-workflows`.